### PR TITLE
Add Travis CI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^experiments
+^\.travis\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: R
+cache: packages
+warnings_are_errors: false # Set to true later
+r_check_args: --as-cran --run-donttest
+
+# Vignettes and online documentation
+# r_binary_packages:
+#   - knitr
+#   - rmarkdown
+# r_packages:
+#   - pkgdown
+
+branches:
+  only:
+    - master
+
+# before_deploy:
+#   - cp releases/CHANGELOG.md .
+#   - Rscript -e 'install.packages(getwd(), repos = NULL, type = "source"); pkgdown::build_site()'
+#   - cp pkgdown/favicon/* docs/
+# deploy:
+#   provider: pages
+#   local_dir: docs/
+#   skip_cleanup: true
+#   github-token: $GH_TOKEN

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,5 +16,6 @@ Depends:
     bootstrap
 License: GPL (>= 2) | BSD_3_clause + file LICENSE
 RoxygenNote: 7.0.2
-Suggests: 
-    testthat
+Suggests:
+    testthat,
+    mvtnorm

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/synth-inference/synthdid.svg?branch=master)](https://travis-ci.com/synth-inference/synthdid)
+
 # synthdid: Synthetic Difference in Differences Estimation
 
 This package implements the synthetic difference in difference estimator (SDID) for the


### PR DESCRIPTION
Add the basic Travis config.

* The remaining options for online docs can be added later.

* Should also enable warnings as errors later, currently there are way too many.