### PR TITLE
Add a quick fix for faster jackknife standard errors

### DIFF
--- a/R/synthdid.R
+++ b/R/synthdid.R
@@ -160,21 +160,23 @@ synthdid_estimate <- function(Y, N0, T0, X=array(dim=c(dim(Y),0)),
     N1 = nrow(Y)-N0
     T1 = ncol(Y)-T0
 
-    Yc=collapsed.form(Y, N0, T0)
     if(dim(X)[3] == 0) {
         weights$vals = NULL
         if(update.lambda) { 
+            Yc=collapsed.form(Y, N0, T0)
             lambda.opt = sc.weight.fw(Yc, zeta = zeta.lambda, intercept=lambda.intercept, min.decrease=min.decrease, max.iter=max.iter)
             weights$lambda = lambda.opt$lambda
             weights$vals =   lambda.opt$vals
         }
         if(update.omega) {
+            Yc=collapsed.form(Y, N0, T0)
             omega.opt  = sc.weight.fw(t(Yc), zeta = zeta.omega,  intercept=omega.intercept, min.decrease=min.decrease, max.iter=max.iter)
             weights$omega = omega.opt$lambda
             if(is.null(weights$vals)) { weights$vals = omega.opt$vals }
             else { weights$vals = pairwise.sum.decreasing(weights$vals, omega.opt$vals) } 
         }
     } else {
+        Yc=collapsed.form(Y, N0, T0)
         Xc=apply(X, 3, function(Xi) { collapsed.form(Xi, N0, T0) })
         dim(Xc) = c(dim(Yc), dim(X)[3])
         weights = sc.weight.fw.covariates(Yc, Xc, zeta.lambda=zeta.lambda, zeta.omega=zeta.omega,


### PR DESCRIPTION
Computing `collapsed.form(Y, N0, T0)` is not necessary for any of the jackknife steps. Suggestion for now: move this computation to where it is needed.

```R
library(synthdid)
library(mvtnorm)

n_0 <- 1500
n_1 <- 10
T_0 <- 120
T_1 <- 20
n <- n_0 + n_1
T <- T_0 + T_1
tau <- 1
sigma <- .5
rank <- 2
rho <- 0.7
var <- outer(1:T, 1:T, FUN=function(x, y) rho^(abs(x-y)))

W <- (1:n > n_0) %*% t(1:T > T_0)
U <- matrix(rpois(rank * n, sqrt(1:n) / sqrt(n)), n, rank)
V <- matrix(rpois(rank * T, sqrt(1:T) / sqrt(T)), T, rank)
alpha <- outer(10*(1:n)/n, rep(1,T))
beta <-  outer(rep(1,n), 10*(1:T)/T)
mu <- U %*% t(V) + alpha + beta
error <- rmvnorm(n, sigma = var, method = "chol")
Y <- mu + tau * W  + sigma * error
rownames(Y) = 1:n
colnames(Y) = 1:T

tau.hat <- synthdid_estimate(Y,n_0,T_0)

system.time(se <- synthdid_se(tau.hat)) 
# user  system elapsed master 
# 8.187   2.358  10.561 

# user  system elapsed This
# 4.162   1.107   5.276 
```

Future suggestions:

* Can delegate some work to an internal `synthdid.fit` (like `lm.fit`) which does work with less error checking for passing to `jacknife`.

* For even faster SEs: can avoid recomputing [this](https://github.com/synth-inference/synthdid/blob/master/R/synthdid.R#L187) matrix multiplication at each jackknife step and instead update it with the influence of observation j?


