### PR TITLE
fixed issue in synthdid_plot + updated cali plots with wider lines

### DIFF
--- a/R/synthdid.R
+++ b/R/synthdid.R
@@ -377,7 +377,7 @@ synthdid_se = function(estimate, weights = attr(estimate, 'weights')) {
 #' @import ggplot2
 synthdid_plot = function(estimates, treated.name='treated', control.name='synthetic control', force.sc=FALSE, 
 			 facet=NULL, facet.vertical=TRUE, lambda.comparable = !is.null(facet), overlay=0, 
-			 lambda.plot.scale=3, trajectory.linetype=1, effect.curvature = 0,
+			 lambda.plot.scale=3, trajectory.linetype=1, effect.curvature = 0, line.width=.5,
 			 trajectory.alpha=.4, diagram.alpha = .95, effect.alpha=.95, onset.alpha = .3, alpha.multiplier = NULL) {
     if(class(estimates) == 'synthdid_estimate') { estimates = list(estimates) } 
     if(is.null(names(estimates))) { names(estimates) = sprintf('estimate %d', 1:length(estimates)) }
@@ -424,7 +424,7 @@ synthdid_plot = function(estimates, treated.name='treated', control.name='synthe
         sdid.post = as.numeric(control.post + treated.pre - control.pre)
 
         time = as.numeric(colnames(Y))
-        if(length(time) == 0) { time = 1:(T0+T1) }
+        if(length(time) == 0 || !all(is.finite(time))) { time = 1:(T0+T1) }
         pre.time =  lambda.synth  %*% time
         post.time = lambda.target %*% time
 
@@ -500,15 +500,15 @@ synthdid_plot = function(estimates, treated.name='treated', control.name='synthe
     no.sc = function(x) { x[!x$is.sc,] }
 
     p=ggplot() +
-        geom_line(aes(x=x,y=y,color=color,frame=frame, alpha=trajectory.alpha*show),  data=conc$lines, linetype=trajectory.linetype) + 
+        geom_line(aes(x=x,y=y,color=color,frame=frame, alpha=trajectory.alpha*show),  data=conc$lines, linetype=trajectory.linetype, size=line.width) + 
         geom_point(aes(x=x,y=y,color=color,frame=frame, alpha=diagram.alpha*show), data=conc$points, shape=21) +
         geom_point(aes(x=x,y=y,color=color,frame=frame, alpha=diagram.alpha*show), data=no.sc(conc$did.points)) +
-        geom_segment(aes(x=x,xend=xend,y=y,yend=yend,color=color, frame=frame, alpha=diagram.alpha*show), data=no.sc(conc$did.segments)) +
-        geom_segment(aes(x=x,xend=xend,y=y,yend=yend,frame=frame, group=estimate, alpha=.5*diagram.alpha*show), data=no.sc(conc$hallucinated.segments), linetype=2,  color='black') +
-        geom_segment(aes(x=x,xend=xend,y=y,yend=yend,frame=frame, group=estimate, alpha=.4*diagram.alpha*show), data=no.sc(conc$guide.segments), linetype=2, color='black') +
-        geom_vline(aes(xintercept=xintercept, alpha=onset.alpha*show), data=conc$vlines, color='black') + 
-        geom_ribbon(aes(x=x,ymin=ymin,ymax=ymax, group=color, fill=color, alpha=.5*diagram.alpha*show), color='black', data = conc$ribbons, show.legend=FALSE) +
-      	geom_curve(aes(x=x,xend=xend,y=y,yend=yend, alpha=effect.alpha*show),  data=conc$arrows, curvature=effect.curvature, color='black', arrow=arrow(length=unit(.2, 'cm')))
+        geom_segment(aes(x=x,xend=xend,y=y,yend=yend,color=color, frame=frame, alpha=diagram.alpha*show), data=no.sc(conc$did.segments), size=line.width) +
+        geom_segment(aes(x=x,xend=xend,y=y,yend=yend,frame=frame, group=estimate, alpha=.5*diagram.alpha*show), data=no.sc(conc$hallucinated.segments), linetype=2,  size=line.width, color='black') +
+        geom_segment(aes(x=x,xend=xend,y=y,yend=yend,frame=frame, group=estimate, alpha=.4*diagram.alpha*show), data=no.sc(conc$guide.segments), size=line.width, linetype=2, color='black') +
+        geom_vline(aes(xintercept=xintercept, alpha=onset.alpha*show), data=conc$vlines, size=line.width, color='black') + 
+        geom_ribbon(aes(x=x,ymin=ymin,ymax=ymax, group=color, fill=color, alpha=.5*diagram.alpha*show), color='black', data = conc$ribbons, size=line.width, show.legend=FALSE) +
+      	geom_curve(aes(x=x,xend=xend,y=y,yend=yend, alpha=effect.alpha*show),  data=conc$arrows, curvature=effect.curvature, color='black', size=line.width, arrow=arrow(length=unit(.2, 'cm')))
     # facet if we want multiple facets
     if(!all(conc$lines$facet == conc$lines$facet[1])) { 
         if(facet.vertical) { p = p + facet_grid(facet ~ ., scales='free_y') }

--- a/experiments/california_smoking/diagrams.R
+++ b/experiments/california_smoking/diagrams.R
@@ -1,20 +1,38 @@
 source('setup.R')
 source('../../R/synthdid.R')
 library(viridis)
+library(ggplot2)
 sdid = synthdid_estimate(Y, N0, T0)
 sc = sc_estimate(Y, N0, T0)
 did = did_estimate(Y, N0, T0)
 
-### Parallel Trends Plots
-
 # wi: with intercept. Makes plots remove a fraction i in [0,1] of the SDID pre/post difference. i=0 means plot as usual, i=1 means plot overlaid (without parallelogram).
 wi = function(est, i) { attr(est,'intercept') = i; est } 
 
-synthdid_plot(list(did=did, sdid=sdid), facet.vertical=FALSE, control.name='control', lambda.comparable=TRUE, 
-    trajectory.linetype = 1, trajectory.alpha=.5, effect.alpha=.5, diagram.alpha=1, effect.curvature=-.4, onset.alpha=.7) + 
-    theme(legend.position=c(.90,.90), legend.direction='vertical', legend.key=element_blank(), legend.background=element_blank())
-ggsave('figures/sdid-vs-did.pdf', width=7, height=4.5)
+### Parallel Trends Plots
 
+synthdid_plot(list(sdid=sdid), facet.vertical=FALSE, control.name='sdid control', treated.name='california', lambda.comparable=TRUE, 
+    trajectory.linetype = 1, trajectory.alpha=.8, effect.alpha=1, diagram.alpha=1, effect.curvature=-.4, onset.alpha=.7) + 
+    theme(legend.position=c(.90,.90), legend.direction='vertical', legend.key=element_blank(), legend.background=element_blank())
+ggsave('figures/parallel-diagram.pdf', width=7, height=4.5)
+
+synthdid_plot(list(sdid.control=sdid, synthetic.control=sc), facet=c(1,1), treated.name='california', lambda.comparable=TRUE, 
+    trajectory.linetype = 1, trajectory.alpha=.8, effect.alpha=1, diagram.alpha=1, effect.curvature=-.4, onset.alpha=.7) + 
+    theme(legend.position=c(.90,.90), legend.direction='vertical', legend.key=element_blank(), legend.background=element_blank())
+ggsave('figures/parallel-diagram-vs-sc.pdf', width=7, height=4.5)
+
+synthdid_plot(list(sdid=sdid, did=did, sc=sc), facet.vertical=TRUE, control.name='control', treated.name='california', lambda.comparable=TRUE, 
+    trajectory.linetype = 1, trajectory.alpha=.7, effect.alpha=.7, diagram.alpha=1, effect.curvature=-.4, onset.alpha=.7) + 
+    theme(legend.position=c(.90,.97), legend.direction='vertical', legend.key=element_blank(), legend.background=element_blank())
+ggsave('figures/sdid-vs-vert.pdf', width=4, height=8)
+
+estimators = list(did, sc, sdid)
+names(estimators) = c('difference in differences', 'synthetic control', 'synthetic difference in differences')
+synthdid_plot(estimators, facet.vertical=FALSE, control.name='control', treated.name='california', lambda.comparable=TRUE, 
+    trajectory.linetype = 1, trajectory.alpha=.7, effect.alpha=.7, diagram.alpha=1, line.width=.75, effect.curvature=-.4, onset.alpha=.7) + 
+    theme(legend.position=c(.26,.07), legend.direction='horizontal', legend.key=element_blank(), legend.background=element_blank(),
+    strip.background=element_blank(), strip.text.x = element_blank())
+ggsave('figures/parallel-vs-horiz.pdf', width=15, height=5)
 
 # set up the box we zoom in on in plot 5
 time = as.integer(colnames(Y))
@@ -22,6 +40,9 @@ lambda = attr(sdid,'weights')$lambda
 xbox.ind = c(which(lambda > .01)[1], T0+4)
 xbox = time[xbox.ind] + c(-.5,.5)
 ybox = range(Y[N0+1, min(xbox.ind):(max(xbox.ind))]) + c(-4,4)
+
+
+
 estimators = function(i) { l = list(wi(sdid,i), sc, sdid); names(l)=c('sdid', 'sc', ''); l }
 plot.estimators = function(ests, alpha.multiplier) {
     synthdid_plot(ests, alpha.multiplier=alpha.multiplier, facet=rep(1,length(ests)),
@@ -54,11 +75,13 @@ sdid.notwnoi = synthdid_estimate(Y,N0,T0,weights=list(lambda=rep(1/T0,T0)), omeg
 plot.estimators(list(sdid=wi(sdid,0), sdid.noi=wi(sdid.noi, 0), sdid.notwnoi=wi(sdid.notwnoi, 0)), alpha.multiplier=c(1,1,1)) + plot.theme
 ggsave('figures/timeweights-vs-not-nointercept.pdf', width=7, height=4)
 
+
 ### State Plots (Time Weighting vs Not)
 
-estimate = sdid
-setup = attr(estimate, 'setup')
-weights = attr(estimate, 'weights')
+setup = attr(sdid, 'setup')
+weights = attr(sdid, 'weights')
+weights.sc = attr(sc, 'weights')
+weights.did = attr(did, 'weights')
 Y = setup$Y - contract3(setup$X, weights$beta)
 N0 = setup$N0; N1 = nrow(Y)-N0
 T0 = setup$T0; T1 = ncol(Y)-T0
@@ -69,35 +92,49 @@ lambda.post = c(rep(0,T0), rep(1/T1, T1))
 omega.did   = c(rep(1/N0, N0),  rep(0,N1))
 omega.sdid  = c(weights$omega,  rep(0, N1))
 omega.post = c(rep(0,N0),  rep(1/N1, N1))
-intercept.did = c(omega.did %*% Y %*% (lambda.post - lambda.did))
-intercept.sdid = c(omega.sdid %*% Y %*% (lambda.post - lambda.sdid))
+difs.weighted =    as.vector(t(omega.post) %*% Y %*% (lambda.post - lambda.sdid)) -  as.vector(Y[1:N0,] %*% (lambda.post - lambda.sdid))
+difs.unweighted =  as.vector((omega.post) %*% Y %*% (lambda.post - lambda.did))   -  as.vector(Y[1:N0,] %*% (lambda.post - lambda.did))
+difs.sc         =  as.vector((omega.post) %*% Y %*% lambda.post)   -  as.vector(Y[1:N0,] %*% lambda.post)
+points = data.frame(y=c(difs.weighted, difs.unweighted, difs.sc),
+                    state=rep(factor(rownames(Y))[1:N0] ,3),
+		    estimate = rep(c(sum(weights$omega * difs.weighted), sum(weights.did$omega * difs.unweighted), sum(weights.sc$omega * difs.sc)), each=N0),
+                    estimator=rep(factor(c('sdid', 'did', 'sc')), each=N0),
+		    weight = c(weights$omega, weights.did$omega, weights.sc$omega))
+ggplot(points[points$state != 'California', ]) + geom_point(aes(x=state,y=y,color=estimator, size=weight)) + 
+    geom_hline(aes(yintercept=estimate, color=estimator)) +
+    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
+ggsave('figures/individual-differences-all.pdf', width=7, height=4)
+ggplot(points[points$state != 'California' & points$estimator %in% c('sdid', 'sc'), ]) + geom_point(aes(x=state,y=y,color=estimator, size=weight)) + 
+    geom_hline(aes(yintercept=estimate, color=estimator)) +
+    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
+ggsave('figures/individual-differences-sc.pdf', width=7, height=4)
 
-points = data.frame(y=c(Y %*% lambda.post, Y %*% lambda.sdid + intercept.sdid, Y %*% lambda.did + intercept.did),
-                    state=rep(factor(rownames(Y)),3),
-		    ypost = rep(Y %*% lambda.post, 3),
-                    estimate=rep(factor(c('post', 'sdid', 'did')), each=nrow(Y)),
-		    treated=rep(rownames(Y) == 'California', 3))
-ggplot(points) + geom_point(aes(x=state,y=y,color=estimate, shape=treated)) + 
-    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
-ggsave('figures/all-time-parallel.pdf', width=7, height=4)
-ggplot(points[points$estimate != 'post', ]) + geom_point(aes(x=state,y=y-ypost,color=estimate, shape=treated)) + geom_hline(yintercept=0, alpha=.5) +
-    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
-ggsave('figures/all-time-parallel-relative.pdf', width=7, height=4)
-ggplot(points[points$estimate != 'post' & points$state != 'California', ]) + geom_boxplot(aes(x=estimate, y=y-ypost)) + theme_light()
-ggsave('figures/all-time-parallel-boxplot.pdf', width=7, height=4)
 
-Y = Y[omega.sdid+omega.post > .02, ]
-points = data.frame(y=c(Y %*% lambda.post, Y %*% lambda.sdid + intercept.sdid, Y %*% lambda.did + intercept.did),
-                    state=rep(factor(rownames(Y)),3),
-		    ypost = rep(Y %*% lambda.post, 3),
-                    estimate=rep(factor(c('post', 'sdid', 'did')), each=nrow(Y)),
-		    treated=rep(rownames(Y) == 'California', 3))
-ggplot(points) + geom_point(aes(x=state,y=y,color=estimate, shape=treated)) + 
-    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
-ggsave('figures/sc-time-parallel.pdf', width=7, height=4)
-ggplot(points[points$estimate != 'post', ]) + geom_point(aes(x=state,y=y-ypost,color=estimate, shape=treated)) +  geom_hline(yintercept=0, alpha=.5) +
-    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1)) 
-ggsave('figures/sc-time-parallel-relative.pdf', width=7, height=4)
-ggplot(points[points$estimate != 'post' & points$state != 'California', ]) + geom_boxplot(aes(x=estimate, y=y-ypost)) + theme_light()
-ggsave('figures/sc-time-parallel-boxplot.pdf', width=7, height=4)
+ggplot(points[points$state != 'California', ]) + geom_point(aes(x=state,y=y,size=weight,)) + facet_grid(.~estimator) +
+    geom_hline(aes(yintercept=estimate)) + scale_size(range=c(0,5)) +
+    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1), 
+    legend.background=element_blank(), legend.title = element_blank(), legend.direction='horizontal', legend.position=c(.17,.07))
+    #legend.background=element_blank(), legend.direction='horizontal', legend.position=c(.16,.07))
+ggsave('figures/individual-differences-horiz.pdf', width=15, height=5)
+
+
+
+ggplot(points[points$state != 'California', ]) + 
+    geom_point(aes(x=state,y=y,size=weight), data=points[points$state != 'California' & points$weight > .001, ]) +
+    geom_point(aes(x=state,y=y,size=weight), data=points[points$state != 'California' & points$weight <= .001, ], shape=1) +
+    geom_hline(aes(yintercept=estimate)) + facet_grid(.~estimator) + 
+    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1), 
+    legend.background=element_blank(), legend.title = element_blank(), legend.direction='horizontal', legend.position=c(.17,.07))
+    #legend.background=element_blank(), legend.direction='horizontal', legend.position=c(.16,.07))
+ggsave('figures/individual-differences-horiz-nofillzero.pdf', width=15, height=5)
+
+ggplot(points[points$state != 'California', ]) + 
+    geom_point(aes(x=state,y=y,size=weight), data=points[points$state != 'California' & points$weight > .001, ]) +
+    geom_point(aes(x=state,y=y,size=weight), data=points[points$state != 'California' & points$weight <= .001, ], shape=4, show.legend=FALSE) +
+    geom_hline(aes(yintercept=estimate), size=.75) + facet_grid(.~estimator) + 
+    xlab('') + ylab('') + guides(shape=FALSE) + theme_light() + theme(axis.text.x = element_text(angle = 90, hjust = 1), 
+    legend.background=element_blank(), legend.title = element_blank(), legend.direction='horizontal', legend.position=c(.17,.07), 
+    strip.background=element_blank(), strip.text.x = element_blank())
+ggsave('figures/individual-differences-horiz-xzero.pdf', width=15, height=5)
+
 


### PR DESCRIPTION
issue in synthdid_plot: nothing plotted if colnames(Y) isn't convertible to numeric.
Also: added line.width parameter to synthdid_plot controlling width of lines, widened plots in experiments/california/diagrams

converted mixed dos/unix line endings to unix, so view with whitespace-insensitive diff