### PR TITLE
Remove an old `tau` from test case

### DIFF
--- a/tests/testthat/test_synthdid.R
+++ b/tests/testthat/test_synthdid.R
@@ -31,7 +31,6 @@ test_that("a simple workflow doesn't error", {
   tau.hat = synthdid_estimate(setup$Y,setup$N0,setup$T0)
   se = synthdid_se(tau.hat)
 
-  print(paste("true tau:", tau))
   print(paste0("point estimate: ", round(tau.hat, 2)))
   print(paste0("95% CI for tau: (", round(tau.hat - 1.96 * se, 2), ", ", round(tau.hat + 1.96 * se, 2), ")"))
   plot(tau.hat)
@@ -50,6 +49,3 @@ test_that("adjustment for covariates works: random noise less influential if pas
 
   expect_lt(abs(tau.hat - tau.hat.cov), abs(tau.hat - tau.hat.noise))
 })
-
-
-


### PR DESCRIPTION
Removing an accidental `tau` left behind in fd66c8f, see https://github.com/synth-inference/synthdid/commit/fd66c8f55da9fb34ba2d550c73ee2e673c117092#r40092369

```
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
  Loading required package: ggplot2
  > 
  > test_check("synthdid")
  ── 1. Error: a simple workflow doesn't error (@test_synthdid.R#34)  ────────────
  object 'tau' not found
  Backtrace:
   1. base::print(paste("true tau:", tau))
   2. base::paste("true tau:", tau)
```

An error is still reported for this build because "warnings" are treated as errors. R's package check did not like that #25 forgot to document an argument name (to be addressed later).