### PR TITLE
Fixing default SC lambda weights to be 1/T0 instead of 0

### DIFF
--- a/R/synthdid.R
+++ b/R/synthdid.R
@@ -100,7 +100,7 @@ synthdid_estimate <- function(Y, N0, T0, X = array(dim = c(dim(Y), 0)),
 sc_estimate = function(Y, N0, T0, X = array(dim = c(dim(Y), 0)),
                        zeta.lambda = 0, zeta.omega = sd(apply(Y, 1, diff)),
                        lambda.intercept = FALSE, omega.intercept = FALSE,
-                       weights = list(lambda = rep(0, T0), omega = NULL, vals = NULL),
+                       weights = list(lambda = rep(1/T0, T0), omega = NULL, vals = NULL),
                        min.decrease = 1e-3 * sd(apply(Y, 1, diff)), max.iter = 1e4) {
   estimate = synthdid_estimate(Y, N0, T0, X = X,
     zeta.lambda = zeta.lambda, zeta.omega = zeta.omega,


### PR DESCRIPTION
I was giving a workshop on synthdid at Robinhood when I noticed something peculiar about the standard errors for the Synthetic Control estimate. It seems like these SC estimates can sometimes be a lot larger than those of synthdid or diff-in-diff. (on the order of 2x at times)

I ended up finding that the default weights were set to 0 instead of 1/T0 for calculating the SC estimate. This also lead to pretty different estimates in basic examples. I was wondering if this was an issue/bug (and given how easy it was to fix, I've created a PR for it). Reference: [here](https://github.com/synth-inference/synthdid/blob/8a8be2d7f01e0f7c97b5a69432a0dc41c4e11596/R/synthdid.R#L68)

Here is an example to recreate/illustrate the potential issue I'm seeing. Hopefully this is helpful :)

```python

lm(list=ls())
library(synthdid)
library(ggplot2)
library(mvtnorm)
set.seed(123123)

n_0 <- 100
n_1 <- 10
T_0 <- 120
T_1 <- 20
n <- n_0 + n_1
T <- T_0 + T_1
tau <- 1
sigma <- .5
rank <- 2
rho <- 0.7
var <- outer(1:T, 1:T, FUN=function(x, y) rho^(abs(x-y)))
W <- (1:n > n_0) %*% t(1:T > T_0)
U <- matrix(rpois(rank * n, sqrt(1:n) / sqrt(n)), n, rank)
V <- matrix(rpois(rank * T, sqrt(1:T) / sqrt(T)), T, rank)
alpha <- outer(10*(1:n)/n, rep(1,T))
beta <-  outer(rep(1,n), 10*(1:T)/T)
mu <- U %*% t(V) + alpha + beta
error <- rmvnorm(n, sigma = var, method = "chol")
Y <- mu + tau * W  + sigma * error
rownames(Y) = 1:n
colnames(Y) = 1:T

tau.hat = synthdid::synthdid_estimate(Y,n_0,T_0)
se = synthdid_se(tau.hat)
print(paste("true tau:", tau))
print(paste0("point estimate: ", round(tau.hat, 2)))
print(paste0("95% CI for tau: (", round(tau.hat - 1.96 * se, 2), ", ", round(tau.hat + 1.96 * se, 2), ")"))


tau.hat = synthdid::sc_estimate(Y,n_0,T_0)
se = synthdid_se(tau.hat)
print(paste("true tau:", tau))
print(paste0("point estimate: ", round(tau.hat, 2)))
print(paste0("95% CI for tau: (", round(tau.hat - 1.96 * se, 2), ", ", round(tau.hat + 1.96 * se, 2), ")"))


tau.hat = synthdid::did_estimate(Y,n_0,T_0)
se = synthdid_se(tau.hat)
print(paste("true tau:", tau))
print(paste0("point estimate: ", round(tau.hat, 2)))
print(paste0("95% CI for tau: (", round(tau.hat - 1.96 * se, 2), ", ", round(tau.hat + 1.96 * se, 2), ")"))


sc_estimate = function(Y, N0, T0, X = array(dim = c(dim(Y), 0)),
                       zeta.lambda = 0, zeta.omega = sd(apply(Y, 1, diff)),
                       lambda.intercept = FALSE, omega.intercept = FALSE,
                       weights = list(lambda = rep(1/T0, T0), omega = NULL, vals = NULL),
                       min.decrease = 1e-3 * sd(apply(Y, 1, diff)), max.iter = 1e4) {
  estimate = synthdid_estimate(Y, N0, T0, X = X,
                               zeta.lambda = zeta.lambda, zeta.omega = zeta.omega,
                               lambda.intercept = lambda.intercept, omega.intercept = omega.intercept,
                               weights = weights, min.decrease = min.decrease, max.iter = max.iter)
  attr(estimate, 'estimator') = "sc_estimate"
  estimate
}

tau.hat = sc_estimate(Y,n_0,T_0)
se = synthdid_se(tau.hat)
print(paste("true tau:", tau))
print(paste0("point estimate: ", round(tau.hat, 2)))
print(paste0("95% CI for tau: (", round(tau.hat - 1.96 * se, 2), ", ", round(tau.hat + 1.96 * se, 2), ")"))

```