### PR TITLE
Render vignette on PR to check for errors

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,11 @@ steps:
   - script: ./run.sh dump_logs_by_extension "fail"
     condition: failed()
     displayName: Print test failures
+  - script: |
+  # Test that vignettes render without error
+      Rscript -e "rmarkdown::render('vignettes/synthdid.Rmd')"
+      # Add vignette number two here, etc.
+    displayName: Test vignettes
   # Final deploy step
   # Build the online docs and deploy to gh-pages - only done on master branch.
   # `GITHUB_PAT` is a GitHub access token stored on Azure Pipelines.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ steps:
     condition: failed()
     displayName: Print test failures
   - script: |
-      Rscript -e "install.packages('rmarkdown')"
+      sudo Rscript -e "install.packages('rmarkdown')"
       Rscript -e "rmarkdown::render('vignettes/synthdid.Rmd')"
     displayName: Test vignettes
   # Final deploy step

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ steps:
     condition: failed()
     displayName: Print test failures
   - script: |
+      R CMD INSTALL .
       sudo Rscript -e "install.packages('rmarkdown')"
       Rscript -e "rmarkdown::render('vignettes/synthdid.Rmd')"
     displayName: Test vignettes

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ steps:
     condition: failed()
     displayName: Print test failures
   - script: |
+      Rscript -e "install.packages('rmarkdown')"
       Rscript -e "rmarkdown::render('vignettes/synthdid.Rmd')"
     displayName: Test vignettes
   # Final deploy step

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,9 +35,7 @@ steps:
     condition: failed()
     displayName: Print test failures
   - script: |
-  # Test that vignettes render without error
       Rscript -e "rmarkdown::render('vignettes/synthdid.Rmd')"
-      # Add vignette number two here, etc.
     displayName: Test vignettes
   # Final deploy step
   # Build the online docs and deploy to gh-pages - only done on master branch.


### PR DESCRIPTION
As you make more of these you can test that they render w/o error by adding a new line

```
Rscript -e "rmarkdown::render('vignettes/my_new_vignette.Rmd')"
```
