### PR TITLE
more plotting options for many-unit studies

### DIFF
--- a/man/synthdid_plot.Rd
+++ b/man/synthdid_plot.Rd
@@ -13,6 +13,7 @@ synthdid_plot(
   treated.name = "treated",
   control.name = "synthetic control",
   spaghetti.units = c(),
+  spaghetti.matrices = NULL,
   facet = NULL,
   facet.vertical = TRUE,
   lambda.comparable = !is.null(facet),
@@ -44,6 +45,10 @@ synthdid_plot(
 \item{control.name, }{the name of the control curve that appears in the legend. Defaults to 'synthetic control'}
 
 \item{spaghetti.units, }{a list of units to plot individually. spaghetti.unit \%in\% rownames(Y) must work. Defaults to the empty list.}
+
+\item{spaghetti.matrices, }{a list of matrices --- one for each element of estimates --- of trajectories to plot individually.
+The rows of these matrices should be the same length as the trajectories in Y
+and they must be named --- set rownames(spaghetti.trajectories[[i]]) --- so trajectories can be labeled in the plot.}
 
 \item{facet, }{a list of the same length as estimates indicating the facet in which to plot each estimate.
 The values of the elements of the list are used to label the facets.

--- a/man/synthdid_units_plot.Rd
+++ b/man/synthdid_units_plot.Rd
@@ -11,7 +11,8 @@ synthdid_units_plot(
   estimates,
   negligible.threshold = 0.001,
   negligible.alpha = 0.3,
-  se.method = "jackknife"
+  se.method = "jackknife",
+  units = NULL
 )
 }
 \arguments{
@@ -23,6 +24,8 @@ synthdid_units_plot(
 
 \item{se.method}{the method used to calculate standard errors for the CI. See vcov.synthdid_estimate.
 Defaults to 'jackknife' for speed. If 'none', don't plot a CI.}
+
+\item{units}{a list of control units --- elements of rownames(Y) --- to plot differences for. Defaults to NULL, meaning all of them.}
 }
 \description{
 Plots unit by unit difference-in-differences. Dot size indicates the weights omega_i

--- a/vignettes/more-plotting.Rmd
+++ b/vignettes/more-plotting.Rmd
@@ -2,7 +2,7 @@
 title: "More on Plotting"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{plotting features}
+  %\VignetteIndexEntry{More on Plotting}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -44,6 +44,23 @@ We'll go back to the regularly spaced data from here on.
   
   top.controls = synthdid_controls(estimate)[1:10, , drop=FALSE]
   plot(estimate, spaghetti.units=rownames(top.controls))
+```
+
+We can also pass trajectories of our choice, for example aggregates of controls.
+With fewer of these trajectories, we can make the lines a little more opaque without them getting distracting.
+```{r, fig.width=7.5, fig.height=4}
+  northern.new.england = c('New Hampshire', 'Vermont', 'Maine')
+  spaghetti.matrices = rbind(colMeans(setup$Y[rownames(setup$Y) %in% northern.new.england, ]),
+			                       colMeans(setup$Y[rownames(setup$Y) %in% rownames(top.controls), ]))
+  rownames(spaghetti.matrices) = c('Northern New England States', 'Top-10 Control Average')
+  plot(estimate, spaghetti.matrices=list(spaghetti.matrices), spaghetti.line.alpha=.4)
+```
+
+# Simplifying the Control Unit Contribution Plot
+When we have too many control units, the control unit contribution plot can be too dense to read. 
+We can restrict the units we plot by passing a list of names.
+```{r, fig.width=5, fig.height=5}
+  synthdid_units_plot(estimate, units = rownames(top.controls))
 ```
 
 # Complex Plots


### PR DESCRIPTION
-  new input option for spaghetti plots: pass spaghetti trajectories as a matrix
-  less busy control unit contribution plots: pass units=... to restrict
   what gets plotted